### PR TITLE
docs: add structured reference section to pkgdown config

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -56,70 +56,98 @@ navbar:
       href: "https://github.com/msberends/plot2"
 
 reference:
-  - title: Core Plotting
+  - title: Creating Plots
     desc: >
-      The main entry point for creating plots and the S3 methods that
-      power automatic dispatch for different data types.
+      Everything starts here. The `plot2()` function is the heart of this
+      package -- just pass in your data and it will figure out the best
+      way to visualise it. Whether you have a data frame, a matrix, a
+      statistical model, or even geographic data, `plot2()` knows what to
+      do. Want to layer extra elements on top? Use `add_type()` and its
+      convenient shortcuts to build up your plot step by step.
     contents:
       - plot2
       - plot2-methods
       - add_type
 
-  - title: Plot Customisation
+  - title: Customising Your Plot
     desc: >
-      Functions for tweaking aesthetics, reordering layers, and adding
-      coordinate systems after a plot has been created.
+      Already have a plot but want to fine-tune it? These functions let
+      you change which variables are mapped to visual properties like
+      colour or size, reorder the layers that make up your plot, or
+      switch to a spider (radar) chart layout. Small adjustments can make
+      a big difference in how clearly your data tells its story.
     contents:
       - add_mapping
       - move_layer
       - coord_spider
 
-  - title: Colours
+  - title: Working with Colours
     desc: >
-      Retrieve, create, and manage colour palettes, including
-      colourblind-safe options and custom project colours.
+      Colour is one of the most powerful tools in data visualisation.
+      These functions give you access to a wide range of colour palettes
+      -- including colourblind-friendly options -- and let you define and
+      save your own custom colours for consistent use across all your
+      plots and projects.
     contents:
       - colour
 
-  - title: Theming and Labels
+  - title: Themes and Labels
     desc: >
-      Control the overall look of plots and convert markdown to
-      plotmath expressions for rich-text titles and labels.
+      Great plots deserve a clean, professional look. `theme_minimal2()`
+      gives your plots a modern, print-ready appearance with sensible
+      defaults. The other functions in this section help you use
+      **bold**, *italic*, and other rich formatting in your plot titles
+      and axis labels, and make it easy to extract or customise the
+      title of any plot.
     contents:
       - theme_minimal2
       - md_to_expression
       - get_plot_title
       - labellers
 
-  - title: Formatting
+  - title: Number Formatting
     desc: >
-      Locale-aware number and currency formatting helpers.
+      Numbers on axes and in labels should be easy to read, regardless
+      of where in the world your audience is. These helpers automatically
+      format numbers with the right decimal separator and thousands
+      grouping for your locale, and can display values as euros or
+      dollars.
     contents:
       - dec_mark
 
-  - title: Interactive Use
+  - title: Interactive Plots
     desc: >
-      Convert plots to interactive Plotly widgets or build them
-      interactively with a Shiny app.
+      Want your audience to hover, zoom, and click on your plots? Turn
+      any plot into an interactive widget with `as_plotly()`, or use
+      `create_interactively()` to build a plot from scratch using a
+      point-and-click interface -- no code required.
     contents:
       - plotly
       - create_interactively
 
-  - title: Options
+  - title: Default Settings
     desc: >
-      Package-level options that control default behaviour.
+      Tired of setting the same options every time? Configure your
+      preferred defaults -- such as your go-to colour scheme, font, or
+      decimal format -- once, and every plot you create will
+      automatically use them.
     contents:
       - plot2-options
 
-  - title: Datasets
+  - title: Example Datasets
     desc: >
-      Bundled example datasets for demonstrations and testing.
+      These built-in datasets are ready to use for exploring `plot2()`
+      and trying out different plot types. No need to load external
+      files -- just type the dataset name and start plotting.
     contents:
       - admitted_patients
       - netherlands
 
-  - title: Re-exports
+  - title: Convenience Functions
     desc: >
-      Functions re-exported from dplyr and tidyselect for convenience.
+      A handful of commonly used helper functions from other packages,
+      made available directly through `plot2` so you do not need to load
+      additional packages for everyday tasks like counting rows or
+      selecting columns.
     contents:
       - reexports

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -54,3 +54,72 @@ navbar:
     - text: "Source Code"
       icon: "fab fa-github"
       href: "https://github.com/msberends/plot2"
+
+reference:
+  - title: Core Plotting
+    desc: >
+      The main entry point for creating plots and the S3 methods that
+      power automatic dispatch for different data types.
+    contents:
+      - plot2
+      - plot2-methods
+      - add_type
+
+  - title: Plot Customisation
+    desc: >
+      Functions for tweaking aesthetics, reordering layers, and adding
+      coordinate systems after a plot has been created.
+    contents:
+      - add_mapping
+      - move_layer
+      - coord_spider
+
+  - title: Colours
+    desc: >
+      Retrieve, create, and manage colour palettes, including
+      colourblind-safe options and custom project colours.
+    contents:
+      - colour
+
+  - title: Theming and Labels
+    desc: >
+      Control the overall look of plots and convert markdown to
+      plotmath expressions for rich-text titles and labels.
+    contents:
+      - theme_minimal2
+      - md_to_expression
+      - get_plot_title
+      - labellers
+
+  - title: Formatting
+    desc: >
+      Locale-aware number and currency formatting helpers.
+    contents:
+      - dec_mark
+
+  - title: Interactive Use
+    desc: >
+      Convert plots to interactive Plotly widgets or build them
+      interactively with a Shiny app.
+    contents:
+      - plotly
+      - create_interactively
+
+  - title: Options
+    desc: >
+      Package-level options that control default behaviour.
+    contents:
+      - plot2-options
+
+  - title: Datasets
+    desc: >
+      Bundled example datasets for demonstrations and testing.
+    contents:
+      - admitted_patients
+      - netherlands
+
+  - title: Re-exports
+    desc: >
+      Functions re-exported from dplyr and tidyselect for convenience.
+    contents:
+      - reexports


### PR DESCRIPTION
Organise the reference index into logical groups: Core Plotting,
Plot Customisation, Colours, Theming and Labels, Formatting,
Interactive Use, Options, Datasets, and Re-exports.

https://claude.ai/code/session_01NxquxWVgCJ1nAkT9znXrYe