### PR TITLE
fix: correct pkgdown topic names to match NAMESPACE

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -89,7 +89,7 @@ reference:
       save your own custom colours for consistent use across all your
       plots and projects.
     contents:
-      - colour
+      - get_colour
 
   - title: Themes and Labels
     desc: >
@@ -122,7 +122,7 @@ reference:
       `create_interactively()` to build a plot from scratch using a
       point-and-click interface -- no code required.
     contents:
-      - plotly
+      - as_plotly
       - create_interactively
 
   - title: Default Settings


### PR DESCRIPTION
Two entries in _pkgdown.yml referenced topic names that do not exist:
- 'colour' → the actual topic name in colour.Rd is 'get_colour'
- 'plotly'  → the actual topic name in plotly.Rd is 'as_plotly'

Fixes the pkgdown build error: "is not a known topic".

https://claude.ai/code/session_0166Rv1au4wHk9neqiyz9CLr